### PR TITLE
fix: fail() defined in multiple files

### DIFF
--- a/_tools/syncfiles.txt
+++ b/_tools/syncfiles.txt
@@ -1,5 +1,7 @@
 api/.htaccess
-api/bundles.*
+api/bundles.php
+api/bundles.class.php
+api/bundles.util.php
 api/versioninfo.php
 api/historydata.php
 api/keyboard.php

--- a/api/keyboard.php
+++ b/api/keyboard.php
@@ -1,62 +1,57 @@
 <?php
   require_once('util.php');
-  
+
   /**
     API documentation: https://github.com/sillsdev/keyman/wiki/downloads.keyman.com-API
-    
+
     Gets the available download files for a given keyboard id
   */
-  
+
   header('Content-Type: application/json; charset=utf-8');
   header('Cache-Control: max-age=0');
-  
+
   $allowed_platforms = array('android', 'ios', 'linux', 'mac', 'web', 'windows');
   $allowed_versions = array('1.0'); // api versions, not product versions
   $release_tiers = array('alpha', 'beta', 'stable');
-  
-  function fail($s) {
-    header("HTTP/1.0 400 $s");
-    exit;
-  }
 
   //
   // Parameter checks for version, id
   //
-  
+
   if(isset($_REQUEST['version'])) {
     $version = $_REQUEST['version'];
   } else {
     $version = '1.0';
   }
-  
+
   if(array_search($version, $allowed_versions) === FALSE) {
     fail('Invalid version: Only '.implode('/', $allowed_versions).' allowed');
   }
-  
+
   if(isset($_REQUEST['id'])) {
     $id = $_REQUEST['id'];
   } else {
     fail('id parameter is required');
   }
-  
+
   if(preg_match('/[\\/\:\\\\]/', $id)) {
     fail('id parameter must be a valid id');
   }
-  
+
   /*$tier = 'stable';
   if(isset($_REQUEST['tier'])) {
     $t = $_REQUEST['tier'];
     if(in_array($t, array('alpha', 'beta', 'stable'))) $tier = $t;
   }*/
-  
+
   $result = array();
-  
+
   // Look in the keyboards/ folder for the id
-  
+
   if(!is_dir("../keyboards/$id")) {
     fail('Keyboard '.$id.' does not exist');
   }
-  
+
   $dirs = scandir("../keyboards/$id");
   $dirs = array_filter($dirs, 'special_folders_filter');
   if(count($dirs) == 0) {
@@ -64,10 +59,10 @@
   }
   usort($dirs, 'version_compare_backward');
   $files = scandir("../keyboards/$id/{$dirs[0]}");
-  
+
   // Go through and report on windows, js, kmp downloads.
   // Find the latest Windows download, expecting a format of keymandesktop-<ver>-<id>-<kbdver>.exe
-  
+
   $base = "https://{$_SERVER['SERVER_NAME']}/keyboards/$id/{$dirs[0]}/";
   $winver = '0';
   foreach($files as $file) {
@@ -82,6 +77,6 @@
       $result['js'] = $base . $file;
     }
   }
-      
+
   echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 ?>


### PR DESCRIPTION
Two quick (emergency) issues on downloads.keyman.com arising from a tweet notifying us of a problem: 
https://twitter.com/MuradMoh/status/1191792733876297728

1. `fail()` was moved from bundles.php to util.php but I also had it defined in keyboards.php. I note it is defined in other files but they don't `require()` util.php at this time so have opted not to change them.
2. syncfiles.txt does not support globbing so each file has to be listed.

I have manually updated the site in order to get things running again so we are not under time pressure to merge this.