### PR TITLE
feat: add tsysinfo

### DIFF
--- a/_tools/syncfiles.txt
+++ b/_tools/syncfiles.txt
@@ -17,3 +17,4 @@ developer/.htaccess
 keyboards/.htaccess
 models/.htaccess
 tools/charident/charident.exe
+tools/tsysinfo/tsysinfo.exe


### PR DESCRIPTION
This will be used as a direct download from https://help.keyman.com/kb/40 
for those situations where a user cannot install Keyman Desktop and thus
can't access diagnostics that way. It may be updated periodically but it
is of low importance to do so.

Ref also https://github.com/keymanapp/help.keyman.com/pull/79#discussion_r344533202