### PR TITLE
feat: Add historydata API 2.0 to filter unified HISTORY.md by platform

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -7,6 +7,7 @@ RewriteRule ^version/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$ ve
 
 RewriteRule ^history/(android|ios|linux|mac|web|windows|developer)$ historydata.php?platform=$1 [L]
 RewriteRule ^history/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$ historydata.php?platform=$1&version=$2 [L]
+RewriteRule ^history/(1.0|2.0)$ historydata.php?version=$1 [L]
 
 RewriteRule ^keyboard/(1.0)/(.+)$ keyboard.php?version=$1&id=$2 [L]
 RewriteRule ^keyboard/(.+)$ keyboard.php?id=$1 [L]

--- a/api/.htaccess
+++ b/api/.htaccess
@@ -6,6 +6,7 @@ RewriteRule ^version/(android|ios|linux|mac|web|windows|developer)$ versioninfo.
 RewriteRule ^version/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$ versioninfo.php?platform=$1&version=$2 [L]
 
 RewriteRule ^history/(android|ios|linux|mac|web|windows|developer)$ historydata.php?platform=$1 [L]
+RewriteRule ^history/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$ historydata.php?platform=$1&version=$2 [L]
 
 RewriteRule ^keyboard/(1.0)/(.+)$ keyboard.php?version=$1&id=$2 [L]
 RewriteRule ^keyboard/(.+)$ keyboard.php?id=$1 [L]

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -90,41 +90,44 @@ function filter_for_platform($contents, $platform) {
 
   // Validate platform matches a scope defined in keymanapp/keyman/resources/scopes/scopes.json
   // Also include appropriate 'common' scopes per keymanapp/downloads.keyman.com#30
+  $scope_core_desktop = array('common\/core\/desktop');
+  $scope_core_web = array('common\/core\/web');
+  $scope_models = array('common\/models', 'common\/models\/types', 'common\/models\/templates', 'common\/models\/wordbreakers');
+  $scope_common_resources = array('common\/resources');
+
   switch($platform) {
     case 'linux':
     case 'mac':
     case 'windows':
       $allowed_scopes = array($platform, $platform.'\/config', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/samples',
-        'common\/core\/desktop');
+        $platform.'\/resources', $platform.'\/samples');
+      $allowed_scopes = array_merge($allowed_scopes, $scope_core_desktop);
       break;
 
     case 'developer':
       $allowed_scopes = array($platform, $platform.'\/compilers', $platform.'\/ide',
-        $platform.'\/resources', $platform.'\/tools',
-        'common\/core\/web');
+        $platform.'\/resources', $platform.'\/tools');
+      $allowed_scopes = array_merge($allowed_scopes, $scope_core_web);
       break;
 
     case 'web':
       $allowed_scopes = array($platform, $platform.'\/bookmarklet', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/ui', $platform.'\/tools',
-        'common\/core\/web',
-        'common\/models', 'common\/models\/types', 'common\/models\/templates', 'common\/models\/wordbreakers');
+        $platform.'\/resources', $platform.'\/ui', $platform.'\/tools');
+      $allowed_scopes = array_merge($allowed_scopes, $scope_core_web, $scope_models);
       break;
 
     // Filter out OEM history for android/ios
     case 'android':
     case 'ios':
       $allowed_scopes = array($platform, $platform.'\/app', $platform.'\/browser', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/samples',
-        'common\/core\/web',
-        'common\/models', 'common\/models\/types', 'common\/models\/templates', 'common\/models\/wordbreakers');
+        $platform.'\/resources', $platform.'\/samples');
+      $allowed_scopes = array_merge($allowed_scopes, $scope_core_web, $scope_models);
       break;
     // Invalid platforms already filtered by web.config
   }
 
   // All platforms include common/resources
-  array_push($allowed_scopes, 'common\/resources');
+  $allowed_scopes = array_merge($allowed_scopes, $scope_common_resources);
 
   $scopes_regex = join('|', $allowed_scopes);
   $lines = preg_split("/(\r\n|\n|\r)/", $contents);

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -69,9 +69,6 @@ function get_history_contents($platform, $version) {
     ];
     $contents = preg_replace('/^# Keyman Version History/', '# ' . $platform_title[$platform] . ' Version History', $contents);
 
-    // Append chore for initial creation of 14.0.1 alpha
-    $contents = $contents . "\n\n* chore: Starting 14.0 release\n";
-
     // Append reference to older history
     $contents = $contents . "\n----\n\n" .
       "Older $platform_title[$platform] History available at http://downloads.keyman.com/api/history/$platform\n";
@@ -92,30 +89,42 @@ function filter_for_platform($contents, $platform) {
   $commit_types_regex = join('|', $allowed_commit_types);
 
   // Validate platform matches a scope defined in keymanapp/keyman/resources/scopes/scopes.json
+  // Also include appropriate 'common' scopes per keymanapp/downloads.keyman.com#30
   switch($platform) {
     case 'linux':
     case 'mac':
     case 'windows':
       $allowed_scopes = array($platform, $platform.'\/config', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/samples');
+        $platform.'\/resources', $platform.'\/samples',
+        'common\/core\/desktop');
       break;
+
     case 'developer':
       $allowed_scopes = array($platform, $platform.'\/compilers', $platform.'\/ide',
-        $platform.'\/resources', $platform.'\/tools');
+        $platform.'\/resources', $platform.'\/tools',
+        'common\/core\/web');
       break;
+
     case 'web':
       $allowed_scopes = array($platform, $platform.'\/bookmarklet', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/ui', $platform.'\/tools');
+        $platform.'\/resources', $platform.'\/ui', $platform.'\/tools',
+        'common\/core\/web',
+        'common\/models', 'common\/models\/types', 'common\/models\/templates', 'common\/models\/wordbreakers');
       break;
 
     // Filter out OEM history for android/ios
     case 'android':
     case 'ios':
       $allowed_scopes = array($platform, $platform.'\/app', $platform.'\/browser', $platform.'\/engine',
-        $platform.'\/resources', $platform.'\/samples');
+        $platform.'\/resources', $platform.'\/samples',
+        'common\/core\/web',
+        'common\/models', 'common\/models\/types', 'common\/models\/templates', 'common\/models\/wordbreakers');
       break;
     // Invalid platforms already filtered by web.config
   }
+
+  // All platforms include common/resources
+  array_push($allowed_scopes, 'common\/resources');
 
   $scopes_regex = join('|', $allowed_scopes);
   $lines = preg_split("/(\r\n|\n|\r)/", $contents);

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -133,8 +133,8 @@ function filter_for_platform($contents, $platform) {
   $lines = preg_split("/(\r\n|\n|\r)/", $contents);
 
   // Grep lines that start with '#' | '*'
-  // scope might be separated by ','
-  $filtered_contents = preg_grep("/^(#|\*( )+($commit_types_regex)\(((.)*,)?($scopes_regex)\)).*$/", $lines);
+  // There might be multiple scopes within the '()'
+  $filtered_contents = preg_grep("/^(#|\*( )+($commit_types_regex)\(.*($scopes_regex).*\)).*$/", $lines);
   $filtered_contents = array_values(array_filter($filtered_contents));
 
   // Filter out intermittent releases where $platform wasn't updated

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -121,7 +121,8 @@ function filter_for_platform($contents, $platform) {
   $lines = preg_split("/(\r\n|\n|\r)/", $contents);
 
   // Grep lines that start with '#' | '*'
-  $filtered_contents = preg_grep("/^(#|\*( )+($commit_types_regex)\(($scopes_regex)\)).*$/", $lines);
+  // scope might be separated by ','
+  $filtered_contents = preg_grep("/^(#|\*( )+($commit_types_regex)\(((.)*,)?($scopes_regex)\)).*$/", $lines);
   $filtered_contents = array_values(array_filter($filtered_contents));
 
   // Filter out intermittent releases where $platform wasn't updated

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -68,6 +68,13 @@ function get_history_contents($platform, $version) {
       'developer' => 'Keyman Developer'
     ];
     $contents = preg_replace('/^# Keyman Version History/', '# ' . $platform_title[$platform] . ' Version History', $contents);
+
+    // Append chore for initial creation of 14.0.1 alpha
+    $contents = $contents . "\n\n* chore: Starting 14.0 release\n";
+
+    // Append reference to older history
+    $contents = $contents . "\n----\n\n" .
+      "Older $platform_title[$platform] History available at http://downloads.keyman.com/api/history/$platform\n";
   }
 
   echo $contents;
@@ -88,17 +95,24 @@ function filter_for_platform($contents, $platform) {
   switch($platform) {
     case 'linux':
     case 'mac':
-    case 'web':
     case 'windows':
-    case 'developer':
-      $allowed_scopes = array($platform);
+      $allowed_scopes = array($platform, $platform.'\/config', $platform.'\/engine',
+        $platform.'\/resources', $platform.'\/samples');
       break;
+    case 'developer':
+      $allowed_scopes = array($platform, $platform.'\/compilers', $platform.'\/ide',
+        $platform.'\/resources', $platform.'\/tools');
+      break;
+    case 'web':
+      $allowed_scopes = array($platform, $platform.'\/bookmarklet', $platform.'\/engine',
+        $platform.'\/resources', $platform.'\/ui', $platform.'\/tools');
+      break;
+
     // Filter out OEM history for android/ios
     case 'android':
-      $allowed_scopes = array('android', 'android\/engine', 'android\/app', 'android\/samples');
-      break;
     case 'ios':
-      $allowed_scopes = array('ios', 'ios\/engine', 'ios\/app', 'ios\/samples');
+      $allowed_scopes = array($platform, $platform.'\/app', $platform.'\/browser', $platform.'\/engine',
+        $platform.'\/resources', $platform.'\/samples');
       break;
     // Invalid platforms already filtered by web.config
   }

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -30,17 +30,20 @@ if(array_search($version, $allowed_versions) === FALSE) {
 
 if(isset($_REQUEST['platform'])) {
   $platform = $_REQUEST['platform'];
-  if(!preg_match('/^('.implode('|', $allowed_platforms).')$/', $platform)) {
-    fail('Invalid platform: Only '.implode('/', $allowed_platforms).' allowed');
+  if (!preg_match('/^(' . implode('|', $allowed_platforms) . ')$/', $platform)) {
+    fail('Invalid platform: Only ' . implode('/', $allowed_platforms) . ' allowed');
   }
-} else {
+} else if ($version == '2.0') {
+  $platform = 'all';
+} else if ($version == '1.0') {
+  // platform required for API version 1.0
   fail("Must specify a platform for history.md retrieval!");
 }
 
 // Doing the actual work.
 
 function get_history_contents($platform, $version) {
-// Reads straight from a file.  Likely to be useful for the history-exposing API.
+  // Reads straight from a file.  Likely to be useful for the history-exposing API.
   if ($version == '2.0') {
     $inputURL = "https://raw.githubusercontent.com/keymanapp/keyman/master/HISTORY.md";
   } else {
@@ -53,25 +56,24 @@ function get_history_contents($platform, $version) {
     fail("Cannot locate history information!");
   }
 
-  // Keyman 14.0+ needs to filter history.md by platform
-  if ($version == '2.0') {
+  if (($version == '2.0') && ($platform != 'all')) {
     $contents = filter_for_platform($contents, $platform);
 
     // Update the title for the platform
     $platform_title = [
-      'android' => 'Keyman for Android',
-      'ios' => 'Keyman for iOS',
-      'linux' => 'Keyman for Linux',
-      'mac' => 'Keyman for macOS',
-      'web' => 'KeymanWeb',
-      'windows' => 'Keyman for Windows',
-      'developer' => 'Keyman Developer'
+        'android' => 'Keyman for Android',
+        'ios' => 'Keyman for iOS',
+        'linux' => 'Keyman for Linux',
+        'mac' => 'Keyman for macOS',
+        'web' => 'KeymanWeb',
+        'windows' => 'Keyman for Windows',
+        'developer' => 'Keyman Developer'
     ];
     $contents = preg_replace('/^# Keyman Version History/', '# ' . $platform_title[$platform] . ' Version History', $contents);
 
-    // Append reference to older history
+    // Append reference to platform's older history
     $contents = $contents . "\n----\n\n" .
-      "Older $platform_title[$platform] History available at http://downloads.keyman.com/api/history/$platform\n";
+        "Older $platform_title[$platform] History available at http://downloads.keyman.com/api/history/$platform\n";
   }
 
   echo $contents;

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -42,7 +42,7 @@ if(isset($_REQUEST['platform'])) {
 function get_history_contents($platform, $version) {
 // Reads straight from a file.  Likely to be useful for the history-exposing API.
   if ($version == '2.0') {
-    $inputURL = "./HISTORY.md";
+    $inputURL = "https://raw.githubusercontent.com/keymanapp/keyman/master/HISTORY.md";
   } else {
     $inputURL = "../$platform/history.md";
   }

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -4,18 +4,11 @@
 
     Retrieves HISTORY.md
   */
-
-/**
- * Created by PhpStorm.
- * User: joshua
- * Date: 9/27/2017
- * Time: 1:04 PM
- */
-
 header('Content-Type: text/plain; charset=utf-8');
+header('Cache-Control: max-age=0');
 
 $allowed_platforms = array('android', 'ios', 'linux', 'mac', 'web', 'windows', 'developer');
-$allowed_versions = array('1.0'); // api versions, not product versions
+$allowed_versions = array('1.0', '2.0'); // api versions, not product versions
 //$release_tiers = array('alpha', 'beta', 'stable');
 
 function fail($s) {
@@ -46,18 +39,83 @@ if(isset($_REQUEST['platform'])) {
 
 // Doing the actual work.
 
-function get_history_contents($platform) {
+function get_history_contents($platform, $version) {
 // Reads straight from a file.  Likely to be useful for the history-exposing API.
-  $inputURL = "../$platform/history.md";
+  if ($version == '2.0') {
+    $inputURL = "./HISTORY.md";
+  } else {
+    $inputURL = "../$platform/history.md";
+  }
 
   $contents = @file_get_contents($inputURL);
 
   if($contents === FALSE) {
     fail("Cannot locate history information!");
   }
+
+  // Keyman 14.0+ needs to filter history.md by platform
+  if ($version == '2.0') {
+    $contents = filter_for_platform($contents, $platform);
+
+    // Update the title
+    switch ($platform) {
+      case 'linux':
+      case 'windows':
+      case 'android': $platform_title = 'Keyman for ' . ucfirst($platform); break;
+
+      case 'web': $platform_title = 'KeymanWeb'; break;
+      case 'developer': $platform_title = 'Keyman Developer'; break;
+      case 'mac': $platform_title = 'Keyman for macOS'; break;
+      case 'ios': $platform_title = 'Keyman for iOS'; break;
+    }
+    $contents = preg_replace('/^# Keyman Version History/', '# ' . $platform_title . ' Version History', $contents);
+  }
+
   echo $contents;
 }
 
-get_history_contents($platform);
+/**
+ * Filters the history.md file for a particular platform. Used for Keyman 14.0+
+ * @param $contents
+ * @param $platform
+ * @return string
+ */
+function filter_for_platform($contents, $platform) {
+  // Allowed commit types defined in keymanapp/keyman/resources/scopes/commit-types.json
+  $allowed_commit_types = array('fix', 'feat', 'chore', 'change', 'docs', 'style', 'refactor', 'test', 'auto');
+  $commit_types_regex = join('|', $allowed_commit_types);
+
+  // Validate platform matches a scope defined in keymanapp/keyman/resources/scopes/scopes.json
+  switch($platform) {
+    case 'linux':
+    case 'mac':
+    case 'web':
+    case 'windows':
+    case 'developer':
+      $allowed_scopes = array($platform);
+      break;
+    // Filter out OEM history for android/ios
+    case 'android':
+      $allowed_scopes = array('android', 'android\/engine', 'android\/app', 'android\/samples');
+      break;
+    case 'ios':
+      $allowed_scopes = array('ios', 'ios\/engine', 'ios\/app', 'ios\/samples');
+      break;
+    // Invalid platforms already filtered by web.config
+  }
+
+  $scopes_regex = join('|', $allowed_scopes);
+  $lines = preg_split("/(\r\n|\n|\r)/", $contents);
+
+  // Grep lines that start with '#' | '*' | ' '
+  $filtered_contents = preg_grep("/^(#| |\*( )+($commit_types_regex)\(($scopes_regex)\)).*$/", $lines);
+
+  // TODO: filter out intermittent releases where $platform wasn't updated
+
+  // Add whitespacing back
+  return implode("\n\n", $filtered_contents);
+}
+
+get_history_contents($platform, $version);
 
 ?>

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -56,8 +56,10 @@ function get_history_contents($platform, $version) {
     fail("Cannot locate history information!");
   }
 
-  if (($version == '2.0') && ($platform != 'all')) {
-    $contents = filter_for_platform($contents, $platform);
+  if ($version == '2.0') {
+    if ($platform != 'all') {
+      $contents = filter_for_platform($contents, $platform);
+    }
 
     // Remove the general history title for client to insert
     $contents = preg_replace('/^# Keyman Version History/', '', $contents);

--- a/api/historydata.php
+++ b/api/historydata.php
@@ -35,7 +35,7 @@ if(isset($_REQUEST['platform'])) {
   }
 } else if ($version == '2.0') {
   $platform = 'all';
-} else if ($version == '1.0') {
+} else {
   // platform required for API version 1.0
   fail("Must specify a platform for history.md retrieval!");
 }
@@ -59,21 +59,10 @@ function get_history_contents($platform, $version) {
   if (($version == '2.0') && ($platform != 'all')) {
     $contents = filter_for_platform($contents, $platform);
 
-    // Update the title for the platform
-    $platform_title = [
-        'android' => 'Keyman for Android',
-        'ios' => 'Keyman for iOS',
-        'linux' => 'Keyman for Linux',
-        'mac' => 'Keyman for macOS',
-        'web' => 'KeymanWeb',
-        'windows' => 'Keyman for Windows',
-        'developer' => 'Keyman Developer'
-    ];
-    $contents = preg_replace('/^# Keyman Version History/', '# ' . $platform_title[$platform] . ' Version History', $contents);
+    // Remove the general history title for client to insert
+    $contents = preg_replace('/^# Keyman Version History/', '', $contents);
 
-    // Append reference to platform's older history
-    $contents = $contents . "\n----\n\n" .
-        "Older $platform_title[$platform] History available at http://downloads.keyman.com/api/history/$platform\n";
+    // Leave it to clients to also append reference to platform's older history
   }
 
   echo $contents;

--- a/api/web.config
+++ b/api/web.config
@@ -30,6 +30,10 @@
           <match url="^history/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$" />
           <action type="Rewrite" url="historydata.php?platform={R:1}&amp;version={R:2}" appendQueryString="true" />
         </rule>
+        <rule name="history/v" stopProcessing="true">
+          <match url="^history/(1.0|2.0)$" />
+          <action type="Rewrite" url="historydata.php?version={R:1}" appendQueryString="true" />
+        </rule>
         <!-- keyboard -->
         <rule name="keyboard/v" stopProcessing="true">
           <match url="^keyboard/(1.0)/(.+)$" />

--- a/api/web.config
+++ b/api/web.config
@@ -24,7 +24,11 @@
         <!-- history -->
         <rule name="history/platform" stopProcessing="true">
           <match url="^history/(android|ios|linux|mac|web|windows|developer)$" />
-          <action type="Rewrite" url="history.php?platform={R:1}" appendQueryString="true" />
+          <action type="Rewrite" url="historydata.php?platform={R:1}" appendQueryString="true" />
+        </rule>
+        <rule name="history/platform/v" stopProcessing="true">
+          <match url="^history/(android|ios|linux|mac|web|windows|developer)/(1.0|2.0)$" />
+          <action type="Rewrite" url="historydata.php?platform={R:1}&amp;version={R:2}" appendQueryString="true" />
         </rule>
         <!-- keyboard -->
         <rule name="keyboard/v" stopProcessing="true">


### PR DESCRIPTION
Update historydata API to 2.0 to support keymanapp/help.keyman.com#106
where the unified HISTORY.md file needs to be separated for a platform's version history (Keyman 14.0+)

Older history is still handled by historydata API 1.0

Assumes unified HISTORY.md file is rsynced to `/api/HISTORY.md`