### PR TITLE
chore: disallow robots scanning binary files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,5 +27,11 @@ AddCharset UTF-8 .download_info
 #
 # Rewrite windows/tier/version/keyman-setup+...exe bootstraps
 #
+# We also have a similar rule in our cloudflare front end, to improve
+# caching:
+#    (http.request.full_uri matches "https://downloads.keyman.com/windows/[^/]+/[^/]+/keyman-setup.(.+).exe")
+# Rewrite to:
+#    regex_replace(http.request.uri.path, "/windows/([^/]+)/([^/]+)/keyman-setup.(.+).exe(.*)", "/windows/${1}/${2}/setup.exe${4}")
+#
 
 RewriteRule ^windows/(alpha|beta|stable)/((\d+\.)+\d+)/keyman-setup(\..+)?\.exe$ windows/$1/$2/setup.exe [L]

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,25 @@
+# We don't need bots downloading binary files
+User-agent: *
+Disallow: /*.apk$
+Disallow: /*.dmg$
+Disallow: /*.exe$
+Disallow: /*.gz$
+Disallow: /*.ipa$
+Disallow: /*.kmp$
+Disallow: /*.kmx$
+Disallow: /*.kvk$
+Disallow: /*.msi$
+Disallow: /*.zip$
+
+# symbol files (note, _ is compressed version)
+Disallow: /*.db_$
+Disallow: /*.dbg$
+Disallow: /*.dl_$
+Disallow: /*.dll$
+Disallow: /*.ex_$
+Disallow: /*.pd_$
+Disallow: /*.pdb$
+
 # This bot is too busy (300K+ visits/month across all keyman.com domains)
 User-agent: AhrefsBot
 Disallow: /


### PR DESCRIPTION
I went through a list of all file extensions on downloads.keyman.com, and assessed these ones as the primary ones to ignore.