### PR TITLE
fix: move cache rules from Cloudflare to backend

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,30 @@ AddCharset UTF-8 .model_info
 AddCharset UTF-8 .download_info
 
 #
+# Caching rules for downloads; later rules override earlier ones
+#
+
+# Cache everything except api folder, which is controlled by script response headers
+Header setifempty Cache-Control max-age=2419200 "expr=%{REQUEST_URI} !~ m#^/api/#"
+
+# Never cache directory indexes
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/alpha/$#"
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/beta/$#"
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/stable/$#"
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/alpha/[0-9.]+/$#"
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/beta/[0-9.]+/$#"
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/[a-z]+/stable/[0-9.]+/$#"
+
+# Never cache Windows symbol index
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/windows/symbols/000Admin/#"
+
+# Never cache data folder
+Header set Cache-Control no-cache "expr=%{REQUEST_URI} =~ m#^/data/#"
+
+# Never cache failed requests ('always' applies to failed requests)
+Header always set Cache-Control no-cache "expr=%{REQUEST_STATUS} == 404"
+
+#
 # Keep rules following this point in sync with web.config
 #
 


### PR DESCRIPTION
Fixes #42.

We have more control of caching rules by putting them on the backend server instead of in Cloudflare page rules. The specific rule we needed was to never-cache 404 responses:

```
Header always set Cache-Control no-cache "expr=%{REQUEST_STATUS} == 404"
```

I have disabled all the corresponding Cloudflare page rules except for the /api/ 30-minute edge cache rule, which I will leave enabled for now (we may consider moving this in a future update).

Once we have verified that this is stable, and that caching is still at an appropriate level, I will delete the disabled Cloudflare page rules.

Note that the Cloudflare transform rule for keyman-setup*.exe is still in place so we continue to benefit from the edge cache here (because setup.exe is cached, but not every variation based on keyboard package name). If this Cloudflare rule is disabled, then we fall back to the corresponding .htaccess rule, but we lose the effective caching.